### PR TITLE
Handling of Enter Key in filter boxes

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -3,5 +3,7 @@
 ## Version 1.0 
 *Release Date: 2023-xx-xx*
 
-* **bugfix:** If the discogs client reaches the request limit, the app does not crash but shows an error dialog
+* **bugfix:** If the discogs client reaches the request limit, the app does not crash but 
+shows an error dialog
+* **bugfix:** Filter textboxes accept now ENTER for setting the filter
  

--- a/VinylStudio/MainWindow.xaml
+++ b/VinylStudio/MainWindow.xaml
@@ -142,7 +142,7 @@
         <DockPanel DockPanel.Dock="Right">
             <!-- <Border DockPanel.Dock="Top" Margin="5"> -->
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="5">
-                    <Label Content="Interpret:" />
+                    <Label Name="labelInterpretFilter" Focusable="True" Content="Interpret:" />
                     <TextBox Name="interpretFilter" Width="200" LostFocus="OnFilterInterprets" KeyUp="OnKeyUpInFilterInterprets" />
                 </StackPanel>
             <!-- </Border> -->
@@ -192,7 +192,7 @@
                     <Label Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" Margin="20 0 0 0">Sorting: </Label>
                     <ComboBox Grid.Column="2" Grid.Row="0" Name="comboSorting" SelectedIndex="0" Width="130" SelectionChanged="OnSortingChanged" />
                     <Label Grid.Column="3" Grid.Row="0" VerticalAlignment="Center" Margin="20 0 0 0">Filter: </Label>
-                    <TextBox Grid.Column="4" Grid.Row="0" Name="textboxAlbumFilter" HorizontalAlignment="Stretch" VerticalAlignment="Center" Cursor="" LostFocus="OnAlbumFilterSet" />
+                    <TextBox Grid.Column="4" Grid.Row="0" Name="textboxAlbumFilter" HorizontalAlignment="Stretch" VerticalAlignment="Center" Cursor="" LostFocus="OnAlbumFilterSet" KeyUp="OnKeyUpInFilterThumbnails" />
                 </Grid>
                 <!-- </StackPanel> -->
                 

--- a/VinylStudio/MainWindow.xaml.cs
+++ b/VinylStudio/MainWindow.xaml.cs
@@ -298,14 +298,16 @@ namespace VinylStudio
             }            
         }
 
+        /**
+         * Forced the interpret filter to be set when the user pressed enter by
+         * setting the focus to the label before
+         */
         private void OnKeyUpInFilterInterprets(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.Enter)
             {
-                if (Keyboard.FocusedElement is UIElement nextControl)
-                {
-                    nextControl.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
-                }
+                OnFilterInterprets(sender, e);
+                e.Handled = true;
             }
         }
         
@@ -341,6 +343,10 @@ namespace VinylStudio
                 _thumbnailView.Filter = null;
                 UpdateStatusLine();
             }
+
+            // when interprets are filtered, all selection in the interpret list must be reset
+            // We want to show initially all albums of the interprets that has been filtered
+            interpretList.SelectedItem = null;
         }
 
         /**
@@ -454,6 +460,18 @@ namespace VinylStudio
             }
 
             _thumbnailView?.SortDescriptions.Add(description);
+        }
+
+        /**
+         * Forces the thumbnail filter to be set when the user clicked enter
+         */
+        private void OnKeyUpInFilterThumbnails(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                FilterThumbnails();
+                e.Handled = true;
+            }
         }
 
         /**


### PR DESCRIPTION
The thumbnail filter box did not accept ENTER for setting the filter. The interpret filter box moved to focus to the interpretList and automatically selected the first interpret.

This bad behaviour is now fixed. When pressing enter, both filter boxes set the filter and the input focus stays on the filter box.